### PR TITLE
[追加] セーブデータ構造の定義および管理者データモデルの補完

### DIFF
--- a/docs/implementation/Admin-Data-Models.md
+++ b/docs/implementation/Admin-Data-Models.md
@@ -123,6 +123,7 @@ interface WarehouseState {
 interface StoredMonster {
   id: string;
   typeId: string;
+  attribute: string;
   level: number;
   exp: number;             // 現在の累積経験値
   nextExp: number;         // 次レベルまでの必要累積経験値

--- a/docs/implementation/Implementation-Details.md
+++ b/docs/implementation/Implementation-Details.md
@@ -344,6 +344,16 @@ interface DungeonExitResult {
 }
 ```
 
+### 3.12 SaveData
+```typescript
+interface SaveData {
+  userId: string;          // ユーザーID
+  player: Player;          // プレイヤーの動的ステータス
+  dungeonConfig: DungeonConfig; // 管理しているダンジョンの設定
+  warehouseState: WarehouseState; // 倉庫（ストック）の状態
+}
+```
+
 詳細は **[イベントログ詳細仕様](Event-Log-Schemas.md)** を参照してください。
 
 ## 4. フィールドマップ記号 (Field Map Symbols)


### PR DESCRIPTION
実装に不足していた以下の情報を追加しました。
1. `docs/implementation/Implementation-Details.md` に、セーブデータの全体構造を示す `SaveData` インターフェースの定義を追加。
2. `docs/implementation/Admin-Data-Models.md` の `StoredMonster` インターフェースに、型定義ファイルには存在するがドキュメントに欠落していた `attribute` フィールドを追加。

---
*PR created automatically by Jules for task [10433921089884734055](https://jules.google.com/task/10433921089884734055) started by @yamanakahirofumi*